### PR TITLE
Fix verify code inputs

### DIFF
--- a/.github/workflows/dotnet-build-web-apps-workflow.yml
+++ b/.github/workflows/dotnet-build-web-apps-workflow.yml
@@ -4,44 +4,44 @@ on:
   workflow_call:
     inputs:
       artifactName:
-        description: MyWebProjectThe name to be used when publishing the build artifactsMyWebProject
+        description: The name to be used when publishing the build artifacts
         required: true
         type: string
       dotnetVersion:
-        default: MyWebProject7.0.xMyWebProject
-        description: MyWebProjectThe version of .NET to install onto the runner. Defaults to `7.0.x`.MyWebProject
+        default: 7.0.x
+        description: The version of .NET to install onto the runner. Defaults to `7.0.x`.
         type: string
       semVer:
-        description: MyWebProjectThe version of the application being built. It must be in semantic versioning formatMyWebProject
+        description: The version of the application being built. It must be in semantic versioning format
         required: true
         type: string
       solutionFile:
-        description: MyWebProjectThe path to the solution file to perform `dotnet build` on. Ex. `./src/MySolution.sln`MyWebProject
+        description: The path to the solution file to perform `dotnet build` on. Ex. `./src/MySolution.sln`
         required: true
         type: string
       testCategory:
-        description: MyWebProjectThe test category or trait to use when running `dotnet test`. Deafults to `UnitTest`MyWebProject
-        default: MyWebProjectUnitTestMyWebProject
+        description: The test category or trait to use when running `dotnet test`. Deafults to `UnitTest`
+        default: MyWebProjectUnitTest
         type: string
       unitTestProjectFile:
-        description: MyWebProjectThe file name, including extension, of the project to execute tests for. Ex. `MyWebProject.Tests.csproj`MyWebProject
+        description: The file name, including extension, of the project to execute tests for. Ex. `MyWebProject.Tests.csproj`
         required: true
         type: string
       unitTestProjectFolder:
-        description: MyWebProjectThe folder path that contains the project to run tests for. Ex. `./src/MyWebProject.Tests`MyWebProject
+        description: The folder path that contains the project to run tests for. Ex. `./src/MyWebProject.Tests`
         required: true
         type: string
       webProjectFile:
-        description: MyWebProjectThe file name, including extension, of the web project that will be published. Ex. `MyWebProject.csproj`MyWebProject
+        description: The file name, including extension, of the web project that will be published. Ex. `MyWebProject.csproj`
         required: true
         type: string
       webProjectFolder:
-        description: MyWebProjectThe folder path that contains the web project that will be published. Ex. `./src/MyWebProject`MyWebProject
+        description: The folder path that contains the web project that will be published. Ex. `./src/MyWebProject`
         required: true
         type: string
     secrets:
       CODECOV_TOKEN:
-        description: MyWebProjectThe token used by Codecov to publish code coverage results to.MyWebProject
+        description: The token used by Codecov to publish code coverage results to.
         required: true
 
 jobs:

--- a/.github/workflows/verify-code-style-workflow.yml
+++ b/.github/workflows/verify-code-style-workflow.yml
@@ -9,11 +9,9 @@ on:
           type: string
         solutionFile:
           description: The path to the solution file to perform `dotnet build` on. Ex. `./src/MySolution.sln`.
-          required: true
           type: string
         terraformWorkingDirectory:
           description: The path that contains the Terraform to validate.
-          required: true
           type: string
         verifyCode:
           description: A flag to indicate whether ot not to verify source code formatting. Defaults to `true`.

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ terraformPlanJob:
 This workflow will validating both .NET source code and Terraform code.
 .NET Code is validated using `dotnet format` and Terraform is validated using `terraform fmt -check`.
 You can set flags to turn either checks off depending on individual needs.
+Since you can conditionally run for your source code or Terraform, the `solutionFile` and `terraformWorkingDirectory` are not required inputs.
+However, you will need to specify a value for one or both depending which verify inputs are set to `true`.
 
 ### Usage
 ```yaml
@@ -179,11 +181,9 @@ verifyCodeStyleJob:
     dotnetVersion: ''
 
     # The path to the solution file to perform `dotnet build` on. Ex. `./src/MySolution.sln`
-    # Required: yes
     solutionFile: ''
 
     # The path that contains the Terraform to validate
-    # Required: yes
     terraformWorkingDirectory: ''
 
     # A flag to indicate whether ot not to verify source code formatting.


### PR DESCRIPTION
## Summary
Since you can conditionally specify to verify formatting for the source code, Terraform, or both you can't conditionally require inputs. Having the `solutionFile` and `terraformWorkingDirectory` inputs as optional allows for the consumption of the workflow to be cleaner. The user will still need to specify the correct values based on what they want to verify.