### PR TITLE
Fix repo versioning

### DIFF
--- a/.github/workflows/continuous-delivery-workflow.yml
+++ b/.github/workflows/continuous-delivery-workflow.yml
@@ -15,13 +15,13 @@ jobs:
     name: CD - GitVersion Workflow
     uses: ./.github/workflows/gitversion-workflow.yml
 
-  # tagRepoSemVerJob:
-  #   name: CD - Tag Repo w/ SemVer
-  #   needs: [gitVersionJob]
-  #   uses: ./.github/workflows/tag-repo-workflow.yml
-  #   with:
-  #     semVer: ${{ needs.gitVersionJob.outputs.semVer }}
-  #   secrets: inherit
+  tagRepoSemVerJob:
+    name: CD - Tag Repo w/ SemVer
+    needs: [gitVersionJob]
+    uses: ./.github/workflows/tag-repo-workflow.yml
+    with:
+      semVer: ${{ needs.gitVersionJob.outputs.semVer }}
+    secrets: inherit
 
   tagRepoMajorJob:
     name: Tag Repo w/ Major
@@ -32,6 +32,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
+            console.log("Creating v${{ needs.gitVersionJob.outputs.major }} tag")
             try {
               await github.rest.git.getRef({
                 owner: context.repo.owner,
@@ -56,6 +57,34 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: 'refs/tags/v${{ needs.gitVersionJob.outputs.major }}',
+              sha: context.sha
+            })
+
+            console.log("Creating v${{ needs.gitVersionJob.outputs.majorMinor }} tag")
+            try {
+              await github.rest.git.getRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: 'refs/tags/v${{ needs.gitVersionJob.outputs.majorMinor }}'
+              })
+
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: 'refs/tags/v${{ needs.gitVersionJob.outputs.majorMinor }}'
+              })
+            } catch (error) {
+              if (error.status === 404) {
+                console.log("Tag does not exist")
+              } else {
+                throw error;
+              }
+            }
+
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/v${{ needs.gitVersionJob.outputs.majorMinor }}',
               sha: context.sha
             })
             

--- a/.github/workflows/continuous-delivery-workflow.yml
+++ b/.github/workflows/continuous-delivery-workflow.yml
@@ -15,10 +15,28 @@ jobs:
     name: CD - GitVersion Workflow
     uses: ./.github/workflows/gitversion-workflow.yml
 
-  tagRepoJob:
-    name: CD - Tag Repo Workflow
+  # tagRepoSemVerJob:
+  #   name: CD - Tag Repo w/ SemVer
+  #   needs: [gitVersionJob]
+  #   uses: ./.github/workflows/tag-repo-workflow.yml
+  #   with:
+  #     semVer: ${{ needs.gitVersionJob.outputs.semVer }}
+  #   secrets: inherit
+
+  tagRepoMajorJob:
+    name: Tag Repo w/ Major
     needs: [gitVersionJob]
-    uses: ./.github/workflows/tag-repo-workflow.yml
-    with:
-      semVer: ${{ needs.gitVersionJob.outputs.semVer }}
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create tag
+        uses: actions/github-script@v6
+        with:
+          script: |
+            
+            tag = github.rest.git.getRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/v2'
+            })
+
+            console.log(tag)

--- a/.github/workflows/continuous-delivery-workflow.yml
+++ b/.github/workflows/continuous-delivery-workflow.yml
@@ -44,10 +44,11 @@ jobs:
                 repo: context.repo.repo,
                 ref: 'refs/tags/v${{ needs.gitVersionJob.outputs.major }}'
               })
-            } catch (err) {
-              console.log(typeof err)
-              if(err.constructor === HttpError && err.status === 404) {
-                console.log("Tag not found")
+            } catch (error) {
+              if (error.status === 404) {
+                console.log("Tag does not exist")
+              } else {
+                throw error;
               }
             }
 

--- a/.github/workflows/continuous-delivery-workflow.yml
+++ b/.github/workflows/continuous-delivery-workflow.yml
@@ -32,11 +32,28 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            
-            tag = github.rest.git.getRef({
+            try {
+              await github.rest.git.getRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: 'refs/tags/v${{ needs.gitVersionJob.outputs.major }}'
+              })
+
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: 'refs/tags/v${{ needs.gitVersionJob.outputs.major }}'
+              })
+            } catch (err) {
+              if(err.constructor === HttpError && err.status === 404) {
+                console.log("Tag not found")
+              }
+            }
+
+            github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: 'refs/tags/v2'
+              ref: 'refs/tags/v${{ needs.gitVersionJob.outputs.major }}',
+              sha: context.sha
             })
-
-            console.log(tag)
+            

--- a/.github/workflows/continuous-delivery-workflow.yml
+++ b/.github/workflows/continuous-delivery-workflow.yml
@@ -45,6 +45,7 @@ jobs:
                 ref: 'refs/tags/v${{ needs.gitVersionJob.outputs.major }}'
               })
             } catch (err) {
+              console.log(typeof err)
               if(err.constructor === HttpError && err.status === 404) {
                 console.log("Tag not found")
               }


### PR DESCRIPTION
## Summary
This change allows for a major version and major/minor version tags be set (i.e., `v1` and `v1.2`) when merging changes into `main`. This makes it easier for consumers to pin to specific versions of the workflows. Consumers can pin to the appropriate version that will dictate the level of change they want to accept. Versioning of the repository still needs to follow good Semantic Versioning practices for this to work.

### Using Major
```yaml
jobs:
  gitVersionJob:
    name: CI - GitVersion Workflow
    uses: webstorm-tech/workflows/.github/workflows/gitversion-workflow.yml@v1
```

### Using Major and Minor
```yaml
jobs:
  gitVersionJob:
    name: CI - GitVersion Workflow
    uses: webstorm-tech/workflows/.github/workflows/gitversion-workflow.yml@v1.0
```

### Using Semantic Versioning
```yaml
jobs:
  gitVersionJob:
    name: CI - GitVersion Workflow
    uses: webstorm-tech/workflows/.github/workflows/gitversion-workflow.yml@v1.0.0
```