### PR TITLE
Added ability to specify runner for .NET workflows

### DIFF
--- a/.github/workflows/dotnet-build-app-workflow.yml
+++ b/.github/workflows/dotnet-build-app-workflow.yml
@@ -43,6 +43,10 @@ on:
         description: The folder path that contains the project that will be published. Ex. `./src/MyWebProject`
         required: true
         type: string
+      runner:
+        default: ubuntu-latest
+        description: The runner to use when executing the workflow. Defaults to `ubuntu-latest`.
+        type: string
     secrets:
       CODECOV_TOKEN:
         description: The token used by Codecov to publish code coverage results to. This is required if `unitTestProjectFile` and `unitTestProjectFolder` are provided.
@@ -50,7 +54,7 @@ on:
 jobs:
   buildApplicationJob:
     name: .NET Build and Publish Job
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/dotnet-verify-code-style-workflow.yml
+++ b/.github/workflows/dotnet-verify-code-style-workflow.yml
@@ -10,11 +10,15 @@ on:
         solutionFile:
           description: The path to the solution file to perform `dotnet build` on. Ex. `./src/MySolution.sln`.
           type: string
+        runner:
+          default: ubuntu-latest
+          description: The runner to use when executing the workflow. Defaults to `ubuntu-latest`.
+          type: string
 
 jobs:
   verifyCodeStyleJob:
     name: Verify Code Style
-    runs-on: windows-latest
+    runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -61,6 +61,11 @@ buildApplicationJob:
     # The folder path that contains the project that will be published. Ex. `./src/MyWebProject`
     publishProjectFolder: ''
 
+    # The runner to use when executing the workflow.
+    # Default: ubuntu-latest
+    # Required: no
+    runner: ''
+
   # This is required as the workflow needs access to the `CODECOV_TOKEN` secret
   # Which is needed to publish code coverate results to Codecov
   secrets:
@@ -86,6 +91,11 @@ verifyCodeStyleJob:
 
     # The path to the solution file to perform `dotnet build` on. Ex. `./src/MySolution.sln`
     solutionFile: ''
+
+    # The runner to use when executing the workflow.
+    # Default: ubuntu-latest
+    # Required: no
+    runner: ''
 ```
 
 [dotnet-format]: https://github.com/dotnet/format "dotnet/format repo"


### PR DESCRIPTION
## Summary
Not all .NET workflows can run on a Linux machine (i.e., WinForms). This change allows the user to specify a runner for their workflow which could also be a self-hosted runner. The default is `ubuntu-latest` to ensure backwards compatibility.