### PR TITLE
Add Private NuGet Sources

### DIFF
--- a/.github/workflows/dotnet-build-app-workflow.yml
+++ b/.github/workflows/dotnet-build-app-workflow.yml
@@ -50,6 +50,8 @@ on:
     secrets:
       CODECOV_TOKEN:
         description: The token used by Codecov to publish code coverage results to. This is required if `unitTestProjectFile` and `unitTestProjectFolder` are provided.
+      NUGET_REGISTRIES_JSON:
+        description: A JSON string containing the NuGet registries to use when restoring packages. Ex. `[{"name":"internal","password":"P@$$w0rd","url":"https://nuget.myfeed.local","username":"nuget-user"}]`
 
 jobs:
   buildApplicationJob:
@@ -63,6 +65,14 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ inputs.dotnetVersion }}
+
+      - name: Setup NuGet Registries
+        env:
+          SERIALIZED_NUGET_REGISTRIES: ${{ secrets.NUGET_REGISTRIES_JSON }}
+        if: ${{ env.SERIALIZED_NUGET_REGISTRIES != '' }}
+        uses: webstorm-tech/add-nuget-registry-action@v0.1.17
+        with:
+          serializedNuGetRegistries: ${{ env.SERIALIZED_NUGET_REGISTRIES }}
 
       - name: Build Projects
         run: dotnet build ${{ inputs.solutionFile }} --configuration Release --nologo /p:Version=${{ inputs.semVer }}

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -3,7 +3,10 @@
 ## Build Apps Workflow
 This workflow builds, tests, and publishes artifacts for .NET applications.
 You specify the version of .NET (which has to be a value supported by the `actions/setup-dotnet` action) and it will execute the install.
-Once .NET is setup, it will perform `dotnet build` using `semVer` as the value for the `/p:Version` and `Release` for `--configuration` flags.
+Once .NET is setup, it will attempt to add any NuGet sources specified in the `NUGET_REGISTRIES_JSON` secret.
+It uses the [Add NuGet Regisries](https://github.com/marketplace/actions/add-nuget-registries) action to safely add private sources or sources that require authentication.
+This is an optional step, so if no value is passed in, it will be skipped.
+Next, it will perform `dotnet build` using `semVer` as the value for the `/p:Version` and `Release` for `--configuration` flags.
 After a successful build and a value has been specified for both `unitTestProjectFile` and `unitTestProjectFile`, it will perform `dotnet test` on the specified unit test project.
 Code coverage will be collected in `opencover` format and submitted to Codecov if specified too.
 Next, the workflow will peform a `dotnet publish` on the specified web project.
@@ -66,10 +69,14 @@ buildApplicationJob:
     # Required: no
     runner: ''
 
-  # This is required as the workflow needs access to the `CODECOV_TOKEN` secret
-  # Which is needed to publish code coverate results to Codecov
   secrets:
+    # This is required as the workflow needs access to the token for Codecov
+    # Which is needed to publish code coverate results to Codecov
     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+    # This is optional secret which contains all of the private NuGet soruces
+    # That need to be added to the runner so the dotnet restore is successful
+    NUGET_REGISTRIES_JSON: ${{ secrets.NUGET_REGISTRIES_JSON }}
 ```
 
 ## Verify Code Style Workflow


### PR DESCRIPTION
This pull request includes changes related to setting up NuGet registries and updating the README.md file. The most important changes include adding a new step to the workflow for setting up NuGet registries based on a JSON string provided as a secret and updating the README.md file to explain the purpose of the "CODECOV_TOKEN" and "NUGET_REGISTRIES_JSON" secrets.

Main workflow and secret changes:

* <a href="diffhunk://#diff-68277ddf0e994d8514b2ea7e7b9a86cd8d5fb49c6819aeb3440d3042ab6601d2R69-R76">`.github/workflows/dotnet-build-app-workflow.yml`</a>: Added a new step to the workflow for setting up NuGet registries based on a JSON string provided as a secret. <a href="diffhunk://#diff-68277ddf0e994d8514b2ea7e7b9a86cd8d5fb49c6819aeb3440d3042ab6601d2R69-R76">[1]</a> <a href="diffhunk://#diff-68277ddf0e994d8514b2ea7e7b9a86cd8d5fb49c6819aeb3440d3042ab6601d2R53-R54">[2]</a>

Documentation improvements:

* <a href="diffhunk://#diff-6a095ba1dbd091e3d334d9730c0b4b8bad483c820b14f6e5722c778498189747L6-R9">`dotnet/README.md`</a>: Updated the README.md file to explain the purpose of the "CODECOV_TOKEN" and "NUGET_REGISTRIES_JSON" secrets. <a href="diffhunk://#diff-6a095ba1dbd091e3d334d9730c0b4b8bad483c820b14f6e5722c778498189747L6-R9">[1]</a> <a href="diffhunk://#diff-6a095ba1dbd091e3d334d9730c0b4b8bad483c820b14f6e5722c778498189747L69-R79">[2]</a>