### PR TITLE
Fix `dotnet verify` Restore Error

### DIFF
--- a/.github/workflows/dotnet-verify-code-style-workflow.yml
+++ b/.github/workflows/dotnet-verify-code-style-workflow.yml
@@ -7,13 +7,20 @@ on:
           description: The version of .NET to install onto the runner.
           default: 7.0.x
           type: string
-        solutionFile:
-          description: The path to the solution file to perform `dotnet build` on. Ex. `./src/MySolution.sln`.
-          type: string
+        restore:
+          default: true
+          description: If false, the `--no-restore` flag will be passed to `dotnet format`.
+          type: boolean
         runner:
           default: ubuntu-latest
           description: The runner to use when executing the workflow. Defaults to `ubuntu-latest`.
           type: string
+        solutionFile:
+          description: The path to the solution file to perform `dotnet build` on. Ex. `./src/MySolution.sln`.
+          type: string
+    secrets:
+        NUGET_REGISTRIES_JSON:
+          description: A JSON string containing the NuGet registries to use when restoring packages. Ex. `[{"name":"internal","password":"P@$$w0rd","url":"https://nuget.myfeed.local","username":"nuget-user"}]`
 
 jobs:
   verifyCodeStyleJob:
@@ -28,5 +35,15 @@ jobs:
         with:
           dotnet-version: ${{ inputs.dotnetVersion }}
 
+      - name: Setup NuGet Registries
+        env:
+          SERIALIZED_NUGET_REGISTRIES: ${{ secrets.NUGET_REGISTRIES_JSON }}
+        if: ${{ env.SERIALIZED_NUGET_REGISTRIES != '' }}
+        uses: webstorm-tech/add-nuget-registry-action@v0.1.17
+        with:
+          serializedNuGetRegistries: ${{ env.SERIALIZED_NUGET_REGISTRIES }}
+
       - name: Verify Code Formatting
-        run: dotnet format ${{ inputs.solutionFile }} --severity info --verify-no-changes
+        env:
+          NO_RESTORE_FLAG: ${{ inputs.restore != 'true' && '--no-restore' || '' }}
+        run: dotnet format ${{ inputs.solutionFile }} --severity info --verify-no-changes ${{ env.NO_RESTORE_FLAG }}

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -86,6 +86,12 @@ It is highly recommended that you use an `.editorconfig` to manage your configur
 For more information on `dotnet format`, check out the [`dotnet/format`][dotnet-format] repository.
 You can also read more about the `.editorconfig` file reading the Microsoft documentation [Code-style rule options][ms-code-style] for .NET.
 
+Part of the internals for `dotnet format`, it will attempt to restore dependencies during the exeuction.
+If you have private NuGet sources, this will result in an error while running this workflow.
+The `restore` flag and the `NUGET_REGISTRIES_JSON` secret are provided to help you determine the appropriate path.
+If you simply want to turn of restore by passing the `--no-restore` flag into `dotnet format`, set the `restore` input to `false`.
+If you want to add your private NuGet sources to the runner, pass a secret into the `NUGET_REGISTRIES_JSON` that conforms to the schema as described by the [Add NuGet Registries](add-nuget-registries) action.
+
 ### Usage
 ```yaml
 verifyCodeStyleJob:
@@ -96,14 +102,24 @@ verifyCodeStyleJob:
     # Default: 7.0.x
     dotnetVersion: ''
 
-    # The path to the solution file to perform `dotnet build` on. Ex. `./src/MySolution.sln`
-    solutionFile: ''
+    # If false, the `--no-restore` flag will be passed to `dotnet format`.
+    # Default: true
+    restore: true
 
     # The runner to use when executing the workflow.
     # Default: ubuntu-latest
     # Required: no
     runner: ''
+
+    # The path to the solution file to perform `dotnet build` on. Ex. `./src/MySolution.sln`
+    solutionFile: ''
+
+  secrets:
+    # This is optional secret which contains all of the private NuGet soruces
+    # That need to be added to the runner so the restore is successful
+    NUGET_REGISTRIES_JSON: ${{ secrets.NUGET_REGISTRIES_JSON }}
 ```
 
+[add-nuget-registries]: https://github.com/marketplace/actions/add-nuget-registries
 [dotnet-format]: https://github.com/dotnet/format "dotnet/format repo"
 [ms-code-style]: https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-style-rule-options ".NET Code-style Rule Options"


### PR DESCRIPTION
This pull request includes changes to improve the code style verification workflow and update the README.md file for handling private NuGet sources. The most important changes include adding a new input parameter and secret to the workflow file, and adding a new section to the README.md file explaining how to handle private NuGet sources.

Workflow improvements:

* <a href="diffhunk://#diff-fbb49d56b01cc8ab1267b31b2f0144a8aaa3e54c94e3b0e461a3074c12cbe981L10-R23">`.github/workflows/dotnet-verify-code-style-workflow.yml`</a>: Added a new input parameter `restore` to determine whether the `--no-restore` flag should be passed to the `dotnet format` command.
* <a href="diffhunk://#diff-fbb49d56b01cc8ab1267b31b2f0144a8aaa3e54c94e3b0e461a3074c12cbe981R38-R49">`.github/workflows/dotnet-verify-code-style-workflow.yml`</a>: Added a new secret `NUGET_REGISTRIES_JSON` to specify the NuGet registries to use when restoring packages.
* <a href="diffhunk://#diff-fbb49d56b01cc8ab1267b31b2f0144a8aaa3e54c94e3b0e461a3074c12cbe981L10-R23">`.github/workflows/dotnet-verify-code-style-workflow.yml`</a>: Modified the workflow file to conditionally execute a new step for setting up the NuGet registries based on the presence of the `NUGET_REGISTRIES_JSON` secret. <a href="diffhunk://#diff-fbb49d56b01cc8ab1267b31b2f0144a8aaa3e54c94e3b0e461a3074c12cbe981L10-R23">[1]</a> <a href="diffhunk://#diff-fbb49d56b01cc8ab1267b31b2f0144a8aaa3e54c94e3b0e461a3074c12cbe981R38-R49">[2]</a>
* <a href="diffhunk://#diff-fbb49d56b01cc8ab1267b31b2f0144a8aaa3e54c94e3b0e461a3074c12cbe981L10-R23">`.github/workflows/dotnet-verify-code-style-workflow.yml`</a>: Modified the existing step for verifying code formatting by adding an environment variable `NO_RESTORE_FLAG` to the `dotnet format` command. <a href="diffhunk://#diff-fbb49d56b01cc8ab1267b31b2f0144a8aaa3e54c94e3b0e461a3074c12cbe981L10-R23">[1]</a> <a href="diffhunk://#diff-fbb49d56b01cc8ab1267b31b2f0144a8aaa3e54c94e3b0e461a3074c12cbe981R38-R49">[2]</a>

README.md updates:

* `dotnet/README.md`