### PR TITLE
Fix `NO_RESTORE_FLAG` in Verify Code Formatting Workflow

### DIFF
--- a/.github/workflows/dotnet-verify-code-style-workflow.yml
+++ b/.github/workflows/dotnet-verify-code-style-workflow.yml
@@ -45,5 +45,5 @@ jobs:
 
       - name: Verify Code Formatting
         env:
-          NO_RESTORE_FLAG: ${{ inputs.restore != 'true' && '--no-restore' || '' }}
+          NO_RESTORE_FLAG: ${{ inputs.restore == false && '--no-restore' || '' }}
         run: dotnet format ${{ inputs.solutionFile }} --severity info --verify-no-changes ${{ env.NO_RESTORE_FLAG }}


### PR DESCRIPTION
This pull request includes a change to ensure that the `NO_RESTORE_FLAG` environment variable is correctly set based on the value of `inputs.restore` in the `.github/workflows/dotnet-verify-code-style-workflow.yml` file.

Main change:

* <a href="diffhunk://#diff-fbb49d56b01cc8ab1267b31b2f0144a8aaa3e54c94e3b0e461a3074c12cbe981L48-R48">`.github/workflows/dotnet-verify-code-style-workflow.yml`</a>: Ensured that the `NO_RESTORE_FLAG` environment variable is correctly set based on the value of `inputs.restore`.